### PR TITLE
IR codes fixed

### DIFF
--- a/bin/ps2bootlink
+++ b/bin/ps2bootlink
@@ -3,9 +3,9 @@
 ps2poweron
 
 # hold down L1 for 10 seconds
-irsend send_start ps2 L1
+irsend send_start ps2 KEY_PS2_L1
 sleep 10
-irsend send_stop ps2 L1
+irsend send_stop ps2 KEY_PS2_L1
 
 PIPE=$(mktemp -u)
 mkfifo "$PIPE"

--- a/bin/ps2poweroff
+++ b/bin/ps2poweroff
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-irsend --count=100 send_once ps2 reset
+irsend --count=100 send_once ps2 KEY_PS2_POWEROFF

--- a/bin/ps2poweron
+++ b/bin/ps2poweron
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-irsend --count=10 send_once ps2 reset
+irsend --count=10 send_once ps2 KEY_PS2_POWERON

--- a/lirc/lircd.conf.d/ps2.conf
+++ b/lirc/lircd.conf.d/ps2.conf
@@ -1,12 +1,12 @@
 #
-# this config file was automatically generated
-# using lirc-0.7.0pre6(serial) on Thu Jul 29 18:01:36 2004
+# This config file was calcualted from reverse engineering
 #
-# contributed by Flavio Chierichetti
+# prepared by AKuHAK
 #
 # brand:					Sony
-# model no. of remote control:			SCPH-10420
 # devices being controlled by this remote:	PlayStation 2
+# only ps2 protocol buttons Sony20: 26.218
+# dvd side buttons trimmed out
 
 begin remote
 
@@ -16,68 +16,35 @@ begin remote
   eps            30
   aeps          100
 
-  header       2432   581
-  one          1212   581
-  zero          614   581
-  gap          44853
-  min_repeat      2
+  header       2400   600
+  one          1200   600
+  zero          600   600
+  gap          45000
+  min_repeat      5
   toggle_bit      0
 
 
       begin codes
-          KEY_OPEN                 0x0000000000068B5B        #  Was: OpenClose
-          Reset                    0x00000000000A8B5B
-          KEY_AUDIO                0x0000000000026B92        #  Was: Audio
-          Shuffle                  0x00000000000ACB92
-          KEY_1                    0x0000000000000B92        #  Was: 1
-          KEY_2                    0x0000000000080B92        #  Was: 2
-          KEY_3                    0x0000000000040B92        #  Was: 3
-          KEY_ANGLE                0x00000000000A6B92        #  Was: Angle
-          Program                  0x00000000000F8B92
-          KEY_4                    0x00000000000C0B92        #  Was: 4
-          KEY_5                    0x0000000000020B92        #  Was: 5
-          KEY_6                    0x00000000000A0B92        #  Was: 6
-          KEY_SUBTITLE             0x00000000000C6B92        #  Was: Subtitle
-          KEY_AGAIN                0x0000000000034B92        #  Was: Repeat
-          KEY_7                    0x0000000000060B92        #  Was: 7
-          KEY_8                    0x00000000000E0B92        #  Was: 8
-          KEY_9                    0x0000000000010B92        #  Was: 9
-          SlowLeft                 0x0000000000006B92
-          SlowRight                0x0000000000086B92
-          KEY_CLEAR                0x00000000000F0B92        #  Was: Clear
-          KEY_0                    0x0000000000090B92        #  Was: 0
-          KEY_TIME                 0x0000000000014B92        #  Was: Time
-          ScanLeft                 0x00000000000CCB92
-          ScanRight                0x000000000002CB92
-          KEY_PREVIOUS             0x000000000000CB92        #  Was: Prev
-          KEY_NEXT                 0x000000000008CB92        #  Was: Next
-          AB                       0x0000000000054B92
-          KEY_PLAY                 0x000000000004CB92        #  Was: Play
-          KEY_PAUSE                0x000000000009CB92        #  Was: Pause
-          KEY_STOP                 0x000000000001CB92        #  Was: Stop
-          Display                  0x000000000002AB92
-          TopMenu                  0x0000000000058B92
-          KEY_MENU                 0x00000000000D8B92        #  Was: Menu
-          KEY_ENTER                0x0000000000070B92        #  Was: Return
-          Triangle                 0x000000000003AB5B
-          KEY_UP                   0x000000000009EB92        #  Was: Up
-          Circle                   0x00000000000BAB5B
-          KEY_LEFT                 0x00000000000DEB92        #  Was: Left
-          KEY_ENTER                0x00000000000D0B92        #  Was: Enter
-          KEY_RIGHT                0x000000000003EB92        #  Was: Right
-          Square                   0x00000000000FAB5B
-          KEY_DOWN                 0x000000000005EB92        #  Was: Down
-          Cross                    0x000000000007AB5B
-          L1                       0x000000000005AB5B
-          L2                       0x000000000001AB5B
-          L3                       0x000000000008AB5B
-          R1                       0x00000000000DAB5B
-          R2                       0x000000000009AB5B
-          R3                       0x000000000004AB5B
-          KEY_SELECT               0x000000000000AB5B        #  Was: Select
-          KEY_PLAY                 0x00000000000CAB5B        #  Was: Start
+          KEY_PS2_RESET            0x00000000000A8B5B
+          KEY_PS2_EJECT            0x0000000000068B5B
+          KEY_PS2_POWERON          0x0000000000074B5B
+          KEY_PS2_POWEROFF         0x00000000000F4B5B
+          KEY_PS2_SELECT           0x000000000000AB5B
+          KEY_PS2_L3               0x000000000008AB5B
+          KEY_PS2_R3               0x000000000004AB5B
+          KEY_PS2_START            0x00000000000CAB5B
+          KEY_PS2_UP               0x000000000002AB5B
+          KEY_PS2_RIGHT            0x00000000000AAB5B
+          KEY_PS2_DOWN             0x000000000006AB5B
+          KEY_PS2_LEFT             0x00000000000EAB5B
+          KEY_PS2_L2               0x000000000001AB5B
+          KEY_PS2_R2               0x000000000009AB5B
+          KEY_PS2_L1               0x000000000005AB5B
+          KEY_PS2_R1               0x00000000000DAB5B
+          KEY_PS2_TRIANGLE         0x000000000003AB5B
+          KEY_PS2_CIRCLE           0x00000000000BAB5B
+          KEY_PS2_CROSS            0x000000000007AB5B
+          KEY_PS2_SQUARE           0x00000000000FAB5B
       end codes
 
 end remote
-
-


### PR DESCRIPTION
Fixed Lirc config by fixing some values and adding some useful commands. Power On/Off now can be handled better. Maybe this command can also simplify code in some places.

Codes tested with Broadlink RM4 mini on SCPH-70003